### PR TITLE
Change e-mail placeholder in Code of Conduct

### DIFF
--- a/Code of Conduct.md
+++ b/Code of Conduct.md
@@ -35,7 +35,7 @@ This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be  
-reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All  
+reported by contacting a project maintainer at [ash@ashfurrow.com](mailto:ash@ashfurrow.com). All  
 complaints will be reviewed and investigated and will result in a response that  
 is deemed necessary and appropriate to the circumstances. Maintainers are  
 obligated to maintain confidentiality with regard to the reporter of an  


### PR DESCRIPTION
Change e-mail placeholder in Code of Conduct to real e-mail address.
