### PR TITLE
Add specs for MBP Late 2014 and iMac 21.5"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,8 @@ Computer Model | CPU | RAM | Fresh Build Time | Incremental Build Time |
 -------------- | --- | --- | ---------------- | ---------------------- |
 MacBook (Retina, 12-inch, Early 2015) | 1.1 GHz Intel Core M | 8 GB | 3:00 | 0:12
 MacBook Pro (Retina, 15-inch, Early 2013) | 2.4 GHz Intel Core i7 | 8 GB | 0:47 | 0:10
+MacBook Pro (Retina, 15-inch, Mid 2014) | 2.2 GHz Intel Core i7 | 16 GB | 0:51 | 0:07
+iMac (HDD 1 TB, 21.5-inch, Late 2012) | 2.7 GHz Intel Core i5 | 8 GB | 4:15 | 0:33
 
 Specifications
 --------------


### PR DESCRIPTION
Add specs for
- MacBook Pro Mid 2014, 15", 2.2 GHz, 16 GB, SSD 256 GB
- iMac Late 2012, 21.5", 2.7 GHz, 8 GB, HDD 1 TB
