### PR TITLE
Update statistics with more MBP stats

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ MacBook Pro (Retina, 15-inch, Mid 2014) | 2.2 GHz Intel Core i7 | 16 GB | 0:51 |
 iMac (HDD 1 TB, 21.5-inch, Late 2012) | 2.7 GHz Intel Core i5 | 8 GB | 4:15 | 0:33
 iMac 5K (512GB Flash, 27-inch, Late 2015) | 4.0Ghz Intel Core i7 | 32 GB | 0:28 | 0:06|
 Mac Pro (Flash Storage, Late 2013) | 3.5 GHz 6-Core Intel Xeon E5 | 32 GB | 0:30 | 0:05
+MacBook Pro (15-inch, Early 2011, SSD) | 2.0 GHz Intel Core i& | 8 GB | 1:01 | 0:10 
 
 
 


### PR DESCRIPTION
The average of four trials each of "fresh" and "incremental" builds, as described in the _Specifications_ section, have been added for an Early-2011 15" MacBook Pro running a 2.0GHz quad-core i7 processor with 8GB of RAM and a 500GB Samsung 850 EVO SSD drive.
