### PR TITLE
Add results for rMBP 15" 2.5 GHz Mid 2015

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,7 @@ These are the results from running Xcode on a non-trivial open source project us
 💻 | MacBook Pro </br>Retina, 15", Early 2013 | 2.4 GHz i7 | 8 GB | 0:47 | 0:10
 💻 | MacBook Pro </br>Retina, 15", Late 2013 | 2.3 GHz i7 | 16 GB | 0:53 | 0:09
 💻 | MacBook Pro </br>Retina, 15", Mid 2014 | 2.2 GHz i7 | 16 GB | 0:51 | 0:07
+💻 | MacBook Pro </br>Retina, 15", Mid 2015 | 2.5 GHz i7 | 16 GB | 0:42 | 0:09
 💻 | MacBook Pro </br>Retina, 15", Mid 2015 | 2.8 GHz i7 | 16 GB | 0:39 | 0:07
 ![](assets/mini.jpg) | Mac Mini </br> Mid 2012, 512 SSD | 2.3GHz Quad-Core i7 | 16GB | 0:50 | 0.09
 🖥 | iMac </br>HDD 500 GB, 21.5", Mid 2010 | 3.06 GHz i3 | 12 GB | 3:59 | 0:14


### PR DESCRIPTION
Interestingly, the results were worse a couple of seconds (around 45 seconds for clean builds) when using scaled resolution (1680x1050).
