### PR TITLE
Add MacBook Pro Retina, 13", 2014 to Xcode 9 list

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,7 @@ Xcode 9
 💻 | MacBook Pro <br />Retina, 15", 2017 | 2.9 GHz i7 | 16 GB | 0:49 | 0:16 | 2017-10-09 | :heavy_check_mark:
 💻 | MacBook Pro <br />Retina, 15", 2017 | 2.9 GHz i7 | 16 GB | 0:50 | 0:15 | 2017-10-09 | :x:
 💻 | MacBook Pro <br />Retina, 15", 2015 | 2.8 GHz i7 | 16 GB | 1:17 | 0:12 | 2018-01-02 | :x:
+💻 | MacBook Pro <br />Retina, 13", 2014 | 2.6 GHz i5 | 8 GB | 2:30 | 0:23 | 2018-01-04 | :x:
 ![](assets/mini.jpg) | Mac Mini <br /> Mid 2012, 512 SSD | 2.3 GHz Quad-Core i7 | 16 GB | 1:32 | 0:18 | 2017-10-20 | :x:
 💻 | MacBook Pro <br />Retina, 15", 2017 | 2.8 GHz i7 | 16 GB | 1:50 | 0:14 | | :x:
 💻 | MacBook <br />Retina, 15", Mid 2012 | 2.6 GHz i7 | 8 GB | 2:26 | 0:23 | | :x:


### PR DESCRIPTION
Not sure if there is a specific order to the table, let me know if I should change the row's position.

Interesting to see that it is as fast (or slow) as a 2012 MacBook Pro.
  