### PR TITLE
Adds Mac Pro results for Xcode 9.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,8 @@ Xcode 9
 🖥 | iMac 27" <br />120GB SSD, Mid 2010 | 2.93 GHz i7 | 8 GB | 2:05 | 0:16 | 9.3 | 2018-03-21 | :x:
 💻 | MacBook <br />Retina, 15", Mid 2012 | 2.6 GHz i7 | 8 GB | 2:26 | 0:23 |    | | :x:
 💻 | MacBook Pro <br />13", Mid 2012 | 2.9 GHz i7 | 8 GB | 2:30 | 0:23 |    | | :x:
+![](assets/pro.jpg) | Mac Pro <br />Flash Storage, Late 2013 | 3.7 GHz 4-Core Xeon E5 | 32 GB | 1:15 | 0:10 | 9.4.1 | 2018-06-20 ([commit](https://github.com/artsy/eidolon/commit/e90a1ffd38d73179a6fe2174587dcd98988efc48)) | :x:
+![](assets/pro.jpg) | Mac Pro <br />Flash Storage, Late 2013 | 3.7 GHz 4-Core Xeon E5 | 32 GB | 0:35 | 0:11 | 9.4.1 | 2018-06-20 ([commit](https://github.com/artsy/eidolon/commit/e90a1ffd38d73179a6fe2174587dcd98988efc48)) | :heavy_check_mark:
 
 Xcode 8
 -------


### PR DESCRIPTION
Okay so I ran a few tests and these are the numbers I got for Xcode 9.4.1 on my Mac Pro. One thing to note: I compared the two build systems and was quite impressed! Initially the results weren't promising, but then I saw that the instructions specify to allow indexing to finish first. This extra few seconds after cleaning (which, I don't think cleaning requiring re-indexing on the old system) made a huge difference. 

I also tried this on Xcode 10 beta 2 and got the following results with the new build system:

Clean: 1:10 (longer I think because it was the first time ever launching this simulator), 0:55, 0:53

Incremental: 0.08, 0:08, 0:07

Pretty impressed!