### PR TITLE
MBP 15" 2016 i7 results using Xcode 9.4.1 with new and old build systems

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,8 @@ Xcode 9
 🖥 | iMac 27" <br />5K 1TB SSD, Mid 2017 | 4,2 GHz i7 | 40 GB | 0:49 | 0:08 |    | 2018-01-18 | :x:
 💻 | MacBook Pro <br />Retina, 15", 2017 | 2.9 GHz i7 | 16 GB | 0:49 | 0:16 |    | 2017-10-09 | :heavy_check_mark:
 💻 | MacBook Pro <br />Retina, 15", 2017 | 2.9 GHz i7 | 16 GB | 0:50 | 0:15 |    | 2017-10-09 | :x:
+💻 | MacBook Pro <br />Retina, 15", 2016 | 2.9 GHz i7 | 16 GB | 1:04 | 0:09 | 9.4.1 | 2018-07-18 ([commit](https://github.com/artsy/eidolon/commit/e90a1ffd38d73179a6fe2174587dcd98988efc48)) | :heavy_check_mark:
+💻 | MacBook Pro <br />Retina, 15", 2016 | 2.9 GHz i7 | 16 GB | 1:06 | 0:10 | 9.4.1 | 2018-07-18 ([commit](https://github.com/artsy/eidolon/commit/e90a1ffd38d73179a6fe2174587dcd98988efc48)) | :x:
 💻 | MacBook Pro <br />Retina, 15", 2015 | 2.5 GHz i7 | 16 GB | 0:51 | 0:09 | 9.2 | 2018-03-02 ([commit](https://github.com/artsy/eidolon/commit/e98923f54a3fee3642051b9f48556c5e912591e0)) | :heavy_check_mark:
 🖥 | MacPro Late 2013 | 2.7 GHz 12core Intel Xeon E5 | 64 GB | 0:54 | 0:10 |    | 2018-03-07 ([commit](https://github.com/artsy/eidolon/commit/24c721af3a9991c7c1ebd5dcaef80f470cf5ddcc)) | :x:
 🖥 | iMac 27"<br />256GB SSD, Late 2013 | 3.2 GHz i5 | 24 GB | 0:56 | 0:10 | 9.2 | 2018-03-02 ([commit](https://github.com/artsy/eidolon/commit/e98923f54a3fee3642051b9f48556c5e912591e0)) | :heavy_check_mark:


### PR DESCRIPTION
Updated the results of the 2016 MacBook Pro for Xcode 9.4. The clean build time is in line with the Xcode 8 results, but incremental builds are much faster (could be the simulator is just faster to launch now).