### PR TITLE
Add MacBook Pro 16" with Xcode 12.2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,11 +8,11 @@ Xcode 12
 
 |🖥 | Computer Model | CPU | RAM | Fresh Build Time | Incremental Build Time | Xcode Version | Date & Commit Hash |
 |-- | -------------- | --- | --- | ---------------- | ---------------------- | ---- | ---- |
-|🖥 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:48 | 0:17 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/071ab0fc8ca8aaa3678d7aefd9cf99c594f274ca)) |
-|🖥 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:32 | 0:15 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
-|🖥 | Mac Mini (Late 2020) | Apple M1 | 16 GB | 0:19 | 0:04 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
-|🖥 | Mac Mini (2018) | i7-8700B (3.2GHz) | 32 GB | 0:40 | 0:08 | 12.2 | 2020-11-25 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
-
+|💻 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:48 | 0:17 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/071ab0fc8ca8aaa3678d7aefd9cf99c594f274ca)) |
+|💻 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:32 | 0:15 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
+|![](assets/mini.png) | Mac Mini (Late 2020) | Apple M1 | 16 GB | 0:19 | 0:04 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
+|![](assets/mini-2018.png) | Mac Mini (2018) | i7-8700B (3.2GHz) | 32 GB | 0:40 | 0:08 | 12.2 | 2020-11-25 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
+|💻 | MacBook Pro 16", <br />Retina, 2019 | i9-9880H (2.3 GHz) | 32 GB | 0:31 | 0:07 | 12.2 | 2020-11-26 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 
 Xcode 11
 -------


### PR DESCRIPTION
I've used the iPad Air 4 simulator, and I'm getting a nil deref in Artwork.swift after the app finishes launching. Not sure if that's normal? I've recoreded the time until the loading spinner becomes first visible, I hope that counts as the app fully loading.

Times are averaged from a handful of runs, with the first clean build removed because I'd booted the simulator for the first time, which takes apparently a couple of extra seconds.

I've also updated the icons in the Xcode 12 group.