### PR TITLE
MacBook Pro 15" (Mid 2015)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,7 @@ Xcode 12
 |🖥 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:32 | 0:15 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 |🖥 | Mac Mini (Late 2020) | Apple M1 | 16 GB | 0:19 | 0:04 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 |🖥 | Mac Mini (2018) | i7-8700B (3.2GHz) | 32 GB | 0:40 | 0:08 | 12.2 | 2020-11-25 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
+|💻 | MacBook Pro 15" (Mid 2015) | i7-4770HQ (2.2 GHz) | 16 GB | 0:55 | 0:15 | 12.2 | 2020-11-26 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 
 
 Xcode 11


### PR DESCRIPTION
I also used the iPad Air simulator with same _font-being-nil_ issue as [jlnr](https://github.com/ashfurrow/xcode-hardware-performance/pull/137#issue-527887411) (in [Artwork.swift on line 97](https://github.com/artsy/eidolon/blob/master/Kiosk/App/Models/Artwork.swift#L97)).