### PR TITLE
Add MBP 15-inch Mid 2018 and MBP 13-inch Apple M1 Late 2020 (Xcode 12.3)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,8 @@ Xcode 12
 
 |🖥 | Computer Model | CPU | RAM | Fresh Build Time | Incremental Build Time | Xcode Version | Date & Commit Hash |
 |-- | -------------- | --- | --- | ---------------- | ---------------------- | ---- | ---- |
+|💻 | MacBook Pro 13" (Late 2020) | Apple M1 | 16 GB | 0:21 | 0:04 | 12.3 | 2020-12-27 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
+|💻 | MacBook Pro 15" (Mid 2018) | 2,6 GHz i7-8850H | 16 GB | 0:54 | 0:09 | 12.3 | 2020-12-27 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
 |💻 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:48 | 0:17 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/071ab0fc8ca8aaa3678d7aefd9cf99c594f274ca)) |
 |💻 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:32 | 0:15 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 |![](assets/mini.png) | Mac Mini (Late 2020) | Apple M1 | 16 GB | 0:19 | 0:04 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ Xcode 12
 |🖥 | Computer Model | CPU | RAM | Fresh Build Time | Incremental Build Time | Xcode Version | Date & Commit Hash |
 |-- | -------------- | --- | --- | ---------------- | ---------------------- | ---- | ---- |
 |💻 | MacBook Pro 13" (Late 2020) | Apple M1 | 16 GB | 0:21 | 0:04 | 12.3 | 2020-12-27 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
-|💻 | MacBook Pro 15" (Mid 2018) | 2,6 GHz i7-8850H | 16 GB | 0:54 | 0:09 | 12.3 | 2020-12-27 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
+|💻 | MacBook Pro 15" (Mid 2018) | i7-8850H (2,6 GHz) | 16 GB | 0:54 | 0:09 | 12.3 | 2020-12-27 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
 |💻 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:48 | 0:17 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/071ab0fc8ca8aaa3678d7aefd9cf99c594f274ca)) |
 |💻 | MacBook Pro 13" (Early 2015) | i5-5257U (2.7 GHz) | 16 GB | 1:32 | 0:15 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 |![](assets/mini.png) | Mac Mini (Late 2020) | Apple M1 | 16 GB | 0:19 | 0:04 | 12.2 | 2020-11-20 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
@@ -17,9 +17,9 @@ Xcode 12
 |💻 | MacBook Pro (Late 2020) | Apple M1 | 16 GB | 0:35 | 0:04 | 12.2 | 2020-11-28 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 |💻 | MacBook Pro 16", <br />Retina, 2019 | i9-9880H (2.3 GHz) | 32 GB | 0:31 | 0:07 | 12.2 | 2020-11-26 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
 |💻 | MacBook Pro 15" (Mid 2015) | i7-4770HQ (2.2 GHz) | 16 GB | 0:55 | 0:15 | 12.2 | 2020-11-26 ([commit](https://github.com/artsy/eidolon/commit/f77b605010719683798a49b19101f3027968ebd2)) |
-|🖥  | iMac Pro 27" (Late 2017) | 3.2 GHz 8-Core Intel Xeon W | 32 GB | 0:33 | 0:07 | 12.2 | 2020-12-07 ([commit](https://github.com/artsy/eidolon/commit/https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
-|💻 | MacBook Air (Late 2020) | Apple M1 | 16 GB | 0:33 | 0:06 | 12.2 | 2020-12-07 ([commit](https://github.com/artsy/eidolon/commit/https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
-|💻 | MacBook Air (Late 2018) | I5-8210Y (1.6 GHz) | 8 GB | 2:15 | 0:20 | 12.2 | 2020-12-07 ([commit](https://github.com/artsy/eidolon/commit/https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
+|🖥  | iMac Pro 27" (Late 2017) | 3.2 GHz 8-Core Intel Xeon W | 32 GB | 0:33 | 0:07 | 12.2 | 2020-12-07 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
+|💻 | MacBook Air (Late 2020) | Apple M1 | 16 GB | 0:33 | 0:06 | 12.2 | 2020-12-07 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
+|💻 | MacBook Air (Late 2018) | I5-8210Y (1.6 GHz) | 8 GB | 2:15 | 0:20 | 12.2 | 2020-12-07 ([commit](https://github.com/artsy/eidolon/commit/160767463524fb0219dc08552e9fe38023bd63b2)) |
 
 Xcode 11
 -------


### PR DESCRIPTION
Operating System: macOS Big Sur 11.1
Xcode version: 12.3

Computer: MacBook Pro (15-inch, Mid 2018)
Memory: 16 GB 2400 MHz DDR 4
CPU: Intel Core i7 - 8850H 2,6GHz 

Computer: MacBook Pro (13-inch, Late 2020)
Memory: 16 GB 
CPU: Apple M1

[Full Review](https://hoyelam.com/an-ios-developer-perspective-on-the-macbook-pro-13-inch-m1-2020/) if interested.

---
Also fixed some URL formatting mistakes.  